### PR TITLE
feat: reset de questoes e criacao de exame inicial

### DIFF
--- a/public/js/resultado.js
+++ b/public/js/resultado.js
@@ -102,8 +102,9 @@
       const data = await response.json();
 
       if (!response.ok) {
-        alert(data.message || "Erro ao carregar resultado");
-        window.location.href = "/questionario";
+        // se não tem resultado, o usuário foi resetado ou chegou aqui sem querer
+        // manda pro mapa que é o lugar certo
+        window.location.href = "/mapa";
         return;
       }
 

--- a/src/repositories/progresso.repositories.js
+++ b/src/repositories/progresso.repositories.js
@@ -1,5 +1,10 @@
 // importando as respectivas bibliotecas.
 const pool = require("../database/db");
+const {
+  findOutroGrupoAleatorio,
+  findQualquerGrupoPorModulo,
+  criarExameInicial,
+} = require("./questoes.repositories");
 
 // marca a história de um módulo como concluída.
 async function concluirHistoria(idUsuario, idModulo) {
@@ -18,7 +23,7 @@ async function concluirHistoria(idUsuario, idModulo) {
       concluido_em = CURRENT_TIMESTAMP
     RETURNING *
     `,
-    [idUsuario, idModulo]
+    [idUsuario, idModulo],
   );
 
   return result.rows[0] || null;
@@ -43,7 +48,7 @@ async function findProgressoMapa(idUsuario) {
     WHERE pd.id_usuario = $1
     ORDER BY m.id_modulo ASC
     `,
-    [idUsuario]
+    [idUsuario],
   );
 
   return result.rows;
@@ -62,7 +67,7 @@ async function findProgressoDesafio(idUsuario) {
     WHERE id_usuario = $1
     LIMIT 1
     `,
-    [idUsuario]
+    [idUsuario],
   );
 
   return result.rows[0] || null;
@@ -70,7 +75,33 @@ async function findProgressoDesafio(idUsuario) {
 
 // reinicia a run do usuário.
 // IMPORTANTE: artefatos do usuário NÃO devem ser removidos no reset da run
+// NOVA FUNÇÃO: limpa o histórico de grupos usados no módulo 1, permitindo q sorteie do zero novamente
 async function resetarRunDesafios(idUsuario) {
+  // 1. primeiro deleta as respostas dos exames do módulo 1 desse usuário
+  // precisa ser antes porque respostas dependem dos exames (chave estrangeira)
+  await pool.query(
+    `
+    DELETE FROM respostas
+    WHERE id_exame IN (
+      SELECT id_exame FROM exames
+      WHERE id_usuario = $1
+        AND id_modulo = 1
+    )
+    `,
+    [idUsuario],
+  );
+
+  // 2. agora sim pode deletar os exames do módulo 1
+  await pool.query(
+    `
+    DELETE FROM exames
+    WHERE id_usuario = $1
+      AND id_modulo = 1
+    `,
+    [idUsuario],
+  );
+
+  // 3. reseta o progresso da run
   const result = await pool.query(
     `
     UPDATE progresso_desafio
@@ -82,8 +113,17 @@ async function resetarRunDesafios(idUsuario) {
     WHERE id_usuario = $1
     RETURNING *
     `,
-    [idUsuario]
+    [idUsuario],
   );
+
+  // cria o exame inicial do módulo 1 para o usuário recomeçar
+  let grupo = await findOutroGrupoAleatorio(idUsuario, 1);
+  if (!grupo) {
+    grupo = await findQualquerGrupoPorModulo(1);
+  }
+  if (grupo) {
+    await criarExameInicial(idUsuario, 1, grupo);
+  }
 
   return result.rows[0] || null;
 }
@@ -115,7 +155,7 @@ async function registrarFalhaDesafio(idUsuario) {
     WHERE id_usuario = $1
     RETURNING *
     `,
-    [idUsuario, novasFalhas]
+    [idUsuario, novasFalhas],
   );
 
   return result.rows[0] || null;
@@ -133,7 +173,6 @@ async function avancarDesafio(idUsuario) {
 
   // verifica se chegou no último módulo.
   if (moduloAtual >= 5) {
-
     // libera o certificado.
     const result = await pool.query(
       `
@@ -145,7 +184,7 @@ async function avancarDesafio(idUsuario) {
       WHERE id_usuario = $1
       RETURNING *
       `,
-      [idUsuario]
+      [idUsuario],
     );
 
     return result.rows[0] || null;
@@ -162,7 +201,7 @@ async function avancarDesafio(idUsuario) {
     WHERE id_usuario = $1
     RETURNING *
     `,
-    [idUsuario]
+    [idUsuario],
   );
 
   return result.rows[0] || null;
@@ -178,7 +217,7 @@ async function historiaConcluida(idUsuario, idModulo) {
       AND id_modulo = $2
     LIMIT 1
     `,
-    [idUsuario, idModulo]
+    [idUsuario, idModulo],
   );
 
   return result.rows[0]?.concluido || false;
@@ -192,5 +231,5 @@ module.exports = {
   resetarRunDesafios,
   registrarFalhaDesafio,
   avancarDesafio,
-  historiaConcluida
+  historiaConcluida,
 };

--- a/src/repositories/questoes.repositories.js
+++ b/src/repositories/questoes.repositories.js
@@ -475,6 +475,38 @@ async function findResultadoModuloAtual(idUsuario) {
   };
 }
 
+// verifica se já existe um exame para o usuário nesse módulo
+// retorna o exame se existir, ou null se não existir
+async function findExameExistente(idUsuario, idModulo) {
+  const result = await pool.query(
+    `
+    SELECT id_exame
+    FROM exames
+    WHERE id_usuario = $1
+      AND id_modulo = $2
+    ORDER BY id_exame DESC
+    LIMIT 1
+    `,
+    [idUsuario, idModulo]
+  );
+
+  return result.rows[0] || null;
+}
+
+// cria o exame inicial quando o usuário conclui a história
+async function criarExameInicial(idUsuario, idModulo, grupo) {
+  const result = await pool.query(
+    `
+    INSERT INTO exames (id_usuario, id_modulo, grupo, tentativa)
+    VALUES ($1, $2, $3, 1)
+    RETURNING id_exame, id_usuario, id_modulo, grupo, tentativa
+    `,
+    [idUsuario, idModulo, grupo]
+  );
+
+  return result.rows[0] || null;
+}
+
 module.exports = {
   findProximaQuestaoByUsuario,
   findQuestaoDoExameByUsuario,
@@ -488,5 +520,7 @@ module.exports = {
   updateProximoModulo,
   findModulosRespondidosByUsuario,
   findResultadoModuloAtual,
-  findQualquerGrupoPorModulo
+  findQualquerGrupoPorModulo,
+  findExameExistente,
+  criarExameInicial,
 };

--- a/src/routes/progresso.routes.js
+++ b/src/routes/progresso.routes.js
@@ -1,5 +1,11 @@
 const { Router } = require("express");
 const authMiddleware = require("../middlewares/auth.middleware");
+const {
+  findOutroGrupoAleatorio,
+  findQualquerGrupoPorModulo,
+  findExameExistente,
+  criarExameInicial,
+} = require("../repositories/questoes.repositories");
 
 const {
   concluirHistoria,
@@ -35,15 +41,34 @@ router.get("/mapa", authMiddleware, async function (req, res) {
 
 router.patch("/historia/:idModulo/concluir", authMiddleware, async function (req, res) {
   const idModulo = Number(req.params.idModulo);
-
   if (!Number.isInteger(idModulo) || idModulo <= 0) {
     return res.status(400).json({
       message: "id do módulo inválido",
     });
   }
-
   try {
+    // 1. conclui a história — igual ao que já tinha
     const progresso = await concluirHistoria(req.usuario.id_usuario, idModulo);
+
+    // 2. verifica se já existe um exame para esse módulo
+    // se já existe, não cria outro — evita duplicatas
+    const exameExistente = await findExameExistente(req.usuario.id_usuario, idModulo);
+
+    if (!exameExistente) {
+      // 3. sorteia um grupo aleatório de questões para esse módulo
+      // tenta pegar um grupo que o usuário ainda não usou
+      let grupo = await findOutroGrupoAleatorio(req.usuario.id_usuario, idModulo);
+
+      // se não achar (caso raro), pega qualquer grupo disponível
+      if (!grupo) {
+        grupo = await findQualquerGrupoPorModulo(idModulo);
+      }
+
+      // 4. só cria o exame se encontrou um grupo de questões
+      if (grupo) {
+        await criarExameInicial(req.usuario.id_usuario, idModulo, grupo);
+      }
+    }
 
     return res.status(200).json({
       message: "história concluída",


### PR DESCRIPTION
- ao falhar 2 vezes, deleta respostas e exames do módulo 1 antes de resetar o progresso (corrige erro de chave estrangeira)
- após o reset, cria automaticamente um exame novo no módulo 1 com grupo aleatório diferente
- ao concluir a história, cria o exame inicial automaticamente se ainda não existir
- corrige loop infinito que ocorria após o reset ao tentar carregar resultado sem exame