### PR TITLE
fix: corrigida a vida do boss após sair do desafio e redirecionamento após login

### DIFF
--- a/public/assets/js/mapa.js
+++ b/public/assets/js/mapa.js
@@ -47,10 +47,7 @@ function bloquearMapaAntesDoDesafio1(modulos) {
 
   if (!estaNoModulo1) return;
 
-  if (moduloAtual.historia_concluida) {
-    window.location.href = "/desafio1";
-    return;
-  }
+  if (moduloAtual.historia_concluida) return;
 
   window.location.href = "/capitulo1";
 }

--- a/public/assets/js/questionario1.js
+++ b/public/assets/js/questionario1.js
@@ -746,6 +746,10 @@
         if (q.resposta_salva) {
           confirmadas[q.id_questao] = true;
           respostas[q.id_questao] = q.resposta_salva;
+
+          if (q.resposta_correta_salva) {
+            acertos[q.id_questao] = true;
+          }
         }
       });
 

--- a/src/modules/questoes/questoes.repository.js
+++ b/src/modules/questoes/questoes.repository.js
@@ -742,7 +742,8 @@ async function findTodasQuestoesDoExame(idUsuario) {
       q.alternativa_c,
       q.alternativa_d,
       q.imagem,
-      r.resposta AS resposta_salva
+      r.resposta AS resposta_salva,
+      r.nota AS nota_salva
     FROM exame_atual e
     INNER JOIN questoes q
       ON q.id_modulo = e.id_modulo

--- a/src/modules/questoes/questoes.service.js
+++ b/src/modules/questoes/questoes.service.js
@@ -315,6 +315,7 @@ async function getTodasQuestoesService(idUsuario) {
         imagem: q.imagem ? `/assets/img/questoes/${q.imagem}` : null,
         // 'x' é resposta de questão pulada — não expõe como selecionada
         resposta_salva: q.resposta_salva === 'x' ? 'pulada' : (q.resposta_salva || null),
+        resposta_correta_salva: q.resposta_salva ? Number(q.nota_salva) > 0 : false,
     }));
 }
 


### PR DESCRIPTION
Corrigi a vida do boss para que ao sair e entrar do desafio, ela continue de onde o usuário parou, por exemplo, se ele acertou 5 questões e a vida do boss ficou em 50%, a vida vai continuar em 50% mesmo se ele sair do questionário e voltar depois, seguindo a mesma lógica da permanência das questões.