### PR TITLE
corrige protecao de rota da coleta de artefatos

### DIFF
--- a/public/assets/js/main.js
+++ b/public/assets/js/main.js
@@ -13,6 +13,131 @@
 window.__progressoSessao = window.__progressoSessao || {};
 
 /* =========================================================
+   BARREIRAS DE ACESSO POR PROGRESSO
+========================================================= */
+
+(async function protegerRotasPorProgresso() {
+  const rotaAtual = window.location.pathname;
+  const rotasComBarreira = [
+    "/mapa",
+    "/burningdown",
+    "/artefatos",
+    "/coleta-artefato",
+    "/perfil",
+    "/certificado",
+    "/questionario",
+    "/questionario1",
+    "/resultado",
+  ];
+  const rotaCapitulo = rotaAtual.match(/^\/capitulo([1-5])$/);
+  const rotaDesafio = rotaAtual.match(/^\/desafio([1-5])$/);
+  const precisaValidar =
+    rotaCapitulo || rotaDesafio || rotasComBarreira.includes(rotaAtual);
+
+  if (!precisaValidar || rotaAtual === "/") return;
+
+  const token = localStorage.getItem("token");
+
+  if (!token) {
+    window.location.replace("/");
+    return;
+  }
+
+  try {
+    const progresso = await obterProgressoDaJornada(token);
+    const modulos = Array.isArray(progresso?.modulos) ? progresso.modulos : [];
+    const moduloAtual =
+      modulos.find((modulo) => modulo.desafio_atual) || modulos[0];
+
+    if (!modulos.length || !podeAcessarRotaDaJornada(rotaAtual, modulos)) {
+      window.location.replace(criarRotaSeguraDaJornada(moduloAtual));
+    }
+  } catch (error) {
+    console.warn("Falha ao validar acesso da rota.", error);
+    window.location.replace("/");
+  }
+})();
+
+async function obterProgressoDaJornada(token) {
+  if (window.__progressoSessao.progressoMapa) {
+    return window.__progressoSessao.progressoMapa;
+  }
+
+  const response = await fetch("/api/progresso/mapa", {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error("Nao foi possivel validar o progresso.");
+  }
+
+  const progresso = await response.json();
+  window.__progressoSessao.progressoMapa = progresso;
+  return progresso;
+}
+
+function podeAcessarRotaDaJornada(rota, modulos) {
+  const rotaCapitulo = rota.match(/^\/capitulo([1-5])$/);
+  const rotaDesafio = rota.match(/^\/desafio([1-5])$/);
+  const moduloAtual = modulos.find((modulo) => modulo.desafio_atual);
+
+  if (rotaCapitulo) {
+    const idModulo = Number(rotaCapitulo[1]);
+    const modulo = modulos.find((item) => Number(item.id_modulo) === idModulo);
+    return Boolean(modulo?.historia_liberada);
+  }
+
+  if (rotaDesafio) {
+    const idModulo = Number(rotaDesafio[1]);
+    const modulo = modulos.find((item) => Number(item.id_modulo) === idModulo);
+    return Boolean(modulo?.historia_concluida && modulo?.desafio_atual);
+  }
+
+  if (rota === "/questionario" || rota === "/questionario1") {
+    return Boolean(moduloAtual?.historia_concluida);
+  }
+
+  if (rota === "/certificado") {
+    return modulos.some((modulo) => modulo.certificado_liberado);
+  }
+
+  if (rota === "/artefatos") {
+    const primeiroModulo = modulos.find((modulo) => Number(modulo.id_modulo) === 1);
+    return Boolean(primeiroModulo?.historia_concluida);
+  }
+
+  if (rota === "/coleta-artefato") {
+    const idModulo = Number(new URLSearchParams(window.location.search).get("modulo"));
+    const modulo = modulos.find((item) => Number(item.id_modulo) === idModulo);
+
+    return Boolean(
+      idModulo &&
+        modulo &&
+        modulo.historia_liberada &&
+        (modulo.certificado_liberado || (modulo.historia_concluida && !modulo.desafio_atual))
+    );
+  }
+
+  if (rota === "/resultado") {
+    return Boolean(moduloAtual?.historia_concluida);
+  }
+
+  return true;
+}
+
+function criarRotaSeguraDaJornada(moduloAtual) {
+  const idModuloAtual = Number(moduloAtual?.id_modulo) || 1;
+
+  if (moduloAtual?.historia_concluida) {
+    return `/desafio${idModuloAtual}`;
+  }
+
+  return `/capitulo${idModuloAtual}`;
+}
+
+/* =========================================================
    MENU MOBILE (HEADER)
 ========================================================= */
 

--- a/src/modules/artefatos/artefatos.controller.js
+++ b/src/modules/artefatos/artefatos.controller.js
@@ -69,6 +69,13 @@ async function detalheArtefatoPorModuloController(req, res) {
 
     return res.status(200).json({ success: true, data: artefato });
   } catch (error) {
+    if (error.statusCode) {
+      return res.status(error.statusCode).json({
+        success: false,
+        message: error.message,
+      });
+    }
+
     console.error("Erro em detalheArtefatoPorModuloController:", error);
     return res.status(500).json({ success: false, message: "Erro interno" });
   }

--- a/src/modules/artefatos/artefatos.service.js
+++ b/src/modules/artefatos/artefatos.service.js
@@ -9,7 +9,25 @@ async function obterArtefato(idUsuario, idArtefato) {
 }
 
 async function obterArtefatoPorModulo(idUsuario, idModulo) {
-  return await artefatosRepository.buscarArtefatoPorModulo(idUsuario, idModulo);
+  const artefato = await artefatosRepository.buscarArtefatoPorModulo(
+    idUsuario,
+    idModulo,
+  );
+
+  if (!artefato) return null;
+
+  const podeColetar = await artefatosRepository.usuarioPodeColetarArtefato(
+    idUsuario,
+    artefato.id,
+  );
+
+  if (!artefato.desbloqueado && !podeColetar) {
+    const error = new Error("Artefato ainda não pode ser acessado");
+    error.statusCode = 403;
+    throw error;
+  }
+
+  return artefato;
 }
 
 async function coletarArtefatoDoUsuario(idUsuario, idArtefato) {


### PR DESCRIPTION
## O que foi feito

Corrige a proteção de rotas para impedir acesso direto à tela de coleta de artefatos por URL, como `/coleta-artefato?modulo=3` ou `/coleta-artefato?modulo=5`, quando o usuário ainda não deveria acessar aquele artefato.

## Principais mudanças

- Reintroduzida a validação global de rotas por progresso em `main.js`.
- Ajustada a regra de acesso para `/coleta-artefato`, considerando:
  - módulo liberado;
  - história concluída;
  - módulo não sendo mais o desafio atual;
  - ou certificado já liberado.
- Adicionada proteção no backend para `GET /api/artefatos/modulo/:idModulo`.
- A API agora retorna `403` quando o usuário tenta acessar um artefato ainda bloqueado.

## Validação

- Executado `npm test`.
- As validações de frontend, CSS, EJS, assets principais e imports passaram.
- A suíte ainda possui falhas já existentes relacionadas à estrutura do projeto, como arquivos esperados em `src/routes/index.js`, `src/utils/password.js` e `src/utils/jwt.js`.