### PR TITLE
portal agora permanece aberto

### DIFF
--- a/public/assets/js/capitulo2.js
+++ b/public/assets/js/capitulo2.js
@@ -350,8 +350,6 @@ async function concluirHistoriaCapitulo2() {
 
   const btnConcluir = document.getElementById("btnConcluirHistoriaCapitulo2");
   const btnDesafio = document.getElementById("btnIrDesafioCapitulo2");
-  const porta = document.getElementById("porta2Scene");
-  const portal = document.querySelector(".guardioes-final-portal");
 
   if (btnConcluir) {
     btnConcluir.disabled = true;
@@ -382,13 +380,7 @@ async function concluirHistoriaCapitulo2() {
       btnDesafio.classList.remove("hidden");
     }
 
-    if (porta) {
-      porta.classList.add("porta-liberada");
-    }
-
-    if (portal) {
-      portal.classList.add("is-portal-active");
-    }
+    liberarPortaDesafioCapitulo2();
   } catch (error) {
     console.error(error);
 
@@ -396,6 +388,19 @@ async function concluirHistoriaCapitulo2() {
       btnConcluir.disabled = false;
       btnConcluir.textContent = "Tentar concluir novamente";
     }
+  }
+}
+
+function liberarPortaDesafioCapitulo2() {
+  const porta = document.getElementById("porta2Scene");
+  const portal = document.querySelector(".guardioes-final-portal");
+
+  if (porta) {
+    porta.classList.add("porta-liberada");
+  }
+
+  if (portal) {
+    portal.classList.add("is-portal-active");
   }
 }
 
@@ -422,6 +427,43 @@ function configurarConclusaoCapitulo2() {
       if (!porta.classList.contains("porta-liberada")) return;
       entrarNoDesafioCapitulo2();
     });
+  }
+}
+
+async function carregarEstadoHistoriaCapitulo2() {
+  const token = obterTokenCapitulo2();
+
+  if (!token) return;
+
+  try {
+    const response = await fetch("/api/progresso/mapa", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    const data = await response.json();
+
+    if (!response.ok || !Array.isArray(data.modulos)) return;
+
+    const modulo = data.modulos.find((item) => Number(item.id_modulo) === ID_MODULO);
+
+    if (!modulo?.historia_concluida) return;
+
+    const btnConcluir = document.getElementById("btnConcluirHistoriaCapitulo2");
+    const btnDesafio = document.getElementById("btnIrDesafioCapitulo2");
+
+    if (btnConcluir) {
+      btnConcluir.classList.add("hidden");
+    }
+
+    if (btnDesafio) {
+      btnDesafio.classList.remove("hidden");
+    }
+
+    liberarPortaDesafioCapitulo2();
+  } catch (error) {
+    console.error(error);
   }
 }
 
@@ -468,7 +510,7 @@ function configurarDesbloqueioNavbarCapitulo2() {
   observer.observe(secaoFinal);
 }
 
-document.addEventListener("DOMContentLoaded", () => {
+document.addEventListener("DOMContentLoaded", async () => {
   configurarMangaIntroCapitulo2();
   configurarMangaFinalCapitulo2();
   configurarScrollCapitulo2();
@@ -477,6 +519,7 @@ document.addEventListener("DOMContentLoaded", () => {
   configurarGuardioes();
   configurarPreparoDesafio();
   configurarConclusaoCapitulo2();
+  await carregarEstadoHistoriaCapitulo2();
   configurarParallaxPortalCapitulo2();
   configurarDesbloqueioNavbarCapitulo2();
   ajustarHashInicialCapitulo2();


### PR DESCRIPTION
## O que foi alterado

Corrige o comportamento do portal final do Capítulo 2 para que ele permaneça aberto após a história já ter sido concluída.

Antes, o portal só recebia as classes de liberação no momento em que o usuário clicava para concluir a história. Ao recarregar a página ou retornar ao capítulo depois, o estado visual era perdido, mesmo com o progresso salvo no backend.

Agora, ao carregar o Capítulo 2, o sistema consulta `/api/progresso/mapa`, verifica se a história do módulo 2 já foi concluída e reaplica o estado liberado do portal.

## Detalhes técnicos

- Adicionada função para reaproveitar a lógica de liberação visual do portal.
- Adicionada verificação do estado da história no carregamento da página.
- Mantido o comportamento existente de liberar o portal imediatamente após concluir a história.

## Validação

- Executado `node --check public\assets\js\capitulo2.js`.