### PR TITLE
Responsividade capitulo 1

### DIFF
--- a/public/assets/css/capitulo1.css
+++ b/public/assets/css/capitulo1.css
@@ -1164,6 +1164,31 @@ blockquote {
   }
 }
 
+@media (max-width: 768px) {
+  .runas-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+    justify-items: center;
+    width: 100%;
+    max-width: 100%;
+    overflow: hidden;
+  }
+
+  .runa-btn {
+    width: min(112px, 32vw);
+  }
+
+  .runa-btn img {
+    width: 100%;
+    max-width: 112px;
+  }
+
+  #manifesto .info-card {
+    width: 100%;
+    max-width: 100%;
+  }
+}
+
 body {
   background: #090908;
 }
@@ -1175,25 +1200,44 @@ body {
 
 @media (max-width: 768px) {
   .pilares-scene {
-    min-height: 280px;
+    min-height: 10px;
+  }
+
+  .pilar-btn img {
+    height: clamp(115px, 33vw, 150px);
   }
 
   .pilar-transparencia {
-    left: 6%;
-    bottom: 55%;
-    width: 24%;
+    left: 25%;
+    right: auto;
+    bottom: 53%;
+    width: auto;
+    transform: translateX(-50%);
   }
 
   .pilar-inspecao {
-    left: 35%;
-    bottom: 50%;
-    width: 19%;
+    left: 50%;
+    bottom: 53%;
+    width: auto;
+    transform: translateX(-50%);
   }
 
   .pilar-adaptacao {
-    right: 15%;
-    bottom: 55%;
-    width: 24%;
+    left: 75%;
+    right: auto;
+    bottom: 53%;
+    width: auto;
+    transform: translateX(-50%);
+  }
+
+  .pilar-btn:hover,
+  .pilar-btn:focus,
+  .pilar-btn:active {
+    transform: translateX(-50%) translateY(-4px);
+  }
+
+  #pilares .info-card {
+    margin-top: -2.25rem;
   }
 }
 
@@ -1254,8 +1298,17 @@ body {
 
 @media (max-width: 768px) {
   .story-block {
+    width: calc(100% - 1.5rem);
+    max-width: calc(100vw - 1.5rem);
     padding-left: clamp(1.2rem, 4vw, 2rem);
+    padding-right: clamp(1.2rem, 4vw, 2rem);
     padding-top: 6.5rem;
+    overflow: hidden;
+  }
+
+  .story-text h2 {
+    white-space: normal;
+    overflow-wrap: break-word;
   }
 
   .story-side-icon {

--- a/public/assets/css/capitulo1.css
+++ b/public/assets/css/capitulo1.css
@@ -1195,7 +1195,7 @@ body {
 
 .capitulo-page {
   width: 100%;
-  overflow-x: hidden;
+  overflow-x: clip;
 }
 
 @media (max-width: 768px) {

--- a/public/assets/css/capitulo1.css
+++ b/public/assets/css/capitulo1.css
@@ -1164,6 +1164,15 @@ blockquote {
   }
 }
 
+body {
+  background: #090908;
+}
+
+.capitulo-page {
+  width: 100%;
+  overflow-x: hidden;
+}
+
 @media (max-width: 768px) {
   .pilares-scene {
     min-height: 280px;
@@ -1189,12 +1198,37 @@ blockquote {
 }
 
 @media (max-width: 768px) {
+  header,
+  .header_conteudo,
+  .capitulo-page,
+  .capitulo-hero {
+    width: 100vw;
+    max-width: 100vw;
+  }
+
+  .chapter-progress-wrap {
+    padding: 0.65rem 0;
+  }
+
+  .chapter-progress-wrap.is-fixed {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    width: 100vw;
+    z-index: 1000;
+    background: transparent;
+    backdrop-filter: none;
+    overflow: hidden;
+  }
+
   .chapter-progress {
     justify-content: flex-start;
     flex-wrap: nowrap;
     overflow-x: auto;
     overflow-y: hidden;
-
+    border-radius: 14px;
+    padding: 0.7rem 0.85rem;
     -webkit-overflow-scrolling: touch;
     scrollbar-width: none;
   }
@@ -1206,17 +1240,6 @@ blockquote {
   .progress-item {
     flex: 0 0 auto;
     min-width: 82px;
-  }
-}
-
-@media (max-width: 768px) {
-  .chapter-progress-wrap {
-    padding: 0.65rem 0;
-  }
-
-  .chapter-progress {
-    border-radius: 14px;
-    padding: 0.7rem 0.85rem;
   }
 
   .progress-item img {

--- a/public/assets/js/capitulo1.js
+++ b/public/assets/js/capitulo1.js
@@ -221,6 +221,39 @@ function configurarProgressoVisual() {
   secoes.forEach((secao) => observer.observe(secao));
 }
 
+function configurarBarraProgressoResponsiva() {
+  const barra = document.querySelector(".chapter-progress-wrap");
+
+  if (!barra) return;
+
+  const espaco = document.createElement("div");
+  barra.before(espaco);
+
+  function atualizarBarra() {
+    const mobile = window.innerWidth <= 768;
+
+    if (!mobile) {
+      barra.classList.remove("is-fixed");
+      espaco.style.height = "";
+      return;
+    }
+
+    if (!barra.classList.contains("is-fixed")) {
+      espaco.style.height = "";
+    }
+
+    const limite = espaco.getBoundingClientRect().top + window.scrollY;
+    const fixa = window.scrollY >= limite;
+
+    espaco.style.height = fixa ? `${barra.offsetHeight}px` : "";
+    barra.classList.toggle("is-fixed", fixa);
+  }
+
+  window.addEventListener("scroll", atualizarBarra, { passive: true });
+  window.addEventListener("resize", atualizarBarra);
+  atualizarBarra();
+}
+
 function configurarPilares() {
   const card = document.getElementById("pilar-info");
 
@@ -765,6 +798,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   ajustarScrollPorHashInicial();
   configurarRevealNoScroll();
   configurarProgressoVisual();
+  configurarBarraProgressoResponsiva();
   configurarPilares();
   configurarRunas();
   configurarPrincipios();


### PR DESCRIPTION
Ajusta a responsividade do Capítulo 1, principalmente o comportamento da barra superior de progresso e alguns elementos visuais no mobile.

Principais mudanças

Corrige a barra superior do Capítulo 1 no mobile, seguindo a lógica usada nos Capítulos 2 e 3.
Mantém o comportamento sticky funcionando corretamente no desktop.
Corrige vazamentos horizontais em telas pequenas.
Ajusta a exibição mobile dos pilares da seção “Três Pilares”.
Ajusta a grade das runas para caber corretamente em telas pequenas.
Permite quebra de linha em títulos longos no mobile para evitar estouro lateral.
Validação

Testado visualmente em viewport mobile, incluindo iPhone SE.
Revisado comportamento da barra superior no desktop após os ajustes de overflow.