### PR TITLE
Acessar desafio por capitulos

### DIFF
--- a/public/assets/css/capitulo1.css
+++ b/public/assets/css/capitulo1.css
@@ -1164,6 +1164,31 @@ blockquote {
   }
 }
 
+@media (max-width: 768px) {
+  .runas-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+    justify-items: center;
+    width: 100%;
+    max-width: 100%;
+    overflow: hidden;
+  }
+
+  .runa-btn {
+    width: min(112px, 32vw);
+  }
+
+  .runa-btn img {
+    width: 100%;
+    max-width: 112px;
+  }
+
+  #manifesto .info-card {
+    width: 100%;
+    max-width: 100%;
+  }
+}
+
 body {
   background: #090908;
 }
@@ -1175,25 +1200,44 @@ body {
 
 @media (max-width: 768px) {
   .pilares-scene {
-    min-height: 280px;
+    min-height: 10px;
+  }
+
+  .pilar-btn img {
+    height: clamp(115px, 33vw, 150px);
   }
 
   .pilar-transparencia {
-    left: 6%;
-    bottom: 55%;
-    width: 24%;
+    left: 25%;
+    right: auto;
+    bottom: 53%;
+    width: auto;
+    transform: translateX(-50%);
   }
 
   .pilar-inspecao {
-    left: 35%;
-    bottom: 50%;
-    width: 19%;
+    left: 50%;
+    bottom: 53%;
+    width: auto;
+    transform: translateX(-50%);
   }
 
   .pilar-adaptacao {
-    right: 15%;
-    bottom: 55%;
-    width: 24%;
+    left: 75%;
+    right: auto;
+    bottom: 53%;
+    width: auto;
+    transform: translateX(-50%);
+  }
+
+  .pilar-btn:hover,
+  .pilar-btn:focus,
+  .pilar-btn:active {
+    transform: translateX(-50%) translateY(-4px);
+  }
+
+  #pilares .info-card {
+    margin-top: -2.25rem;
   }
 }
 
@@ -1254,8 +1298,17 @@ body {
 
 @media (max-width: 768px) {
   .story-block {
+    width: calc(100% - 1.5rem);
+    max-width: calc(100vw - 1.5rem);
     padding-left: clamp(1.2rem, 4vw, 2rem);
+    padding-right: clamp(1.2rem, 4vw, 2rem);
     padding-top: 6.5rem;
+    overflow: hidden;
+  }
+
+  .story-text h2 {
+    white-space: normal;
+    overflow-wrap: break-word;
   }
 
   .story-side-icon {

--- a/public/assets/css/capitulo1.css
+++ b/public/assets/css/capitulo1.css
@@ -1195,7 +1195,7 @@ body {
 
 .capitulo-page {
   width: 100%;
-  overflow-x: hidden;
+  overflow-x: clip;
 }
 
 @media (max-width: 768px) {

--- a/public/assets/css/capitulo1.css
+++ b/public/assets/css/capitulo1.css
@@ -1164,6 +1164,15 @@ blockquote {
   }
 }
 
+body {
+  background: #090908;
+}
+
+.capitulo-page {
+  width: 100%;
+  overflow-x: hidden;
+}
+
 @media (max-width: 768px) {
   .pilares-scene {
     min-height: 280px;
@@ -1189,12 +1198,37 @@ blockquote {
 }
 
 @media (max-width: 768px) {
+  header,
+  .header_conteudo,
+  .capitulo-page,
+  .capitulo-hero {
+    width: 100vw;
+    max-width: 100vw;
+  }
+
+  .chapter-progress-wrap {
+    padding: 0.65rem 0;
+  }
+
+  .chapter-progress-wrap.is-fixed {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    width: 100vw;
+    z-index: 1000;
+    background: transparent;
+    backdrop-filter: none;
+    overflow: hidden;
+  }
+
   .chapter-progress {
     justify-content: flex-start;
     flex-wrap: nowrap;
     overflow-x: auto;
     overflow-y: hidden;
-
+    border-radius: 14px;
+    padding: 0.7rem 0.85rem;
     -webkit-overflow-scrolling: touch;
     scrollbar-width: none;
   }
@@ -1206,17 +1240,6 @@ blockquote {
   .progress-item {
     flex: 0 0 auto;
     min-width: 82px;
-  }
-}
-
-@media (max-width: 768px) {
-  .chapter-progress-wrap {
-    padding: 0.65rem 0;
-  }
-
-  .chapter-progress {
-    border-radius: 14px;
-    padding: 0.7rem 0.85rem;
   }
 
   .progress-item img {

--- a/public/assets/css/capitulo1.css
+++ b/public/assets/css/capitulo1.css
@@ -1108,6 +1108,24 @@ blockquote {
   animation: pulsarEntre 1.4s ease-in-out infinite;
 }
 
+.porta-boss-scene.porta-concluida {
+  cursor: default;
+  filter: grayscale(1) brightness(0.72);
+}
+
+.porta-boss-scene.porta-concluida .porta-boss-glow {
+  opacity: 0;
+}
+
+.porta-boss-scene.porta-concluida .porta-entrar-text {
+  opacity: 0;
+}
+
+.porta-boss-scene.porta-concluida .porta-boss-tooltip {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
 @keyframes pulsarEntre {
   0%, 100% {
     text-shadow:

--- a/public/assets/css/capitulo2.css
+++ b/public/assets/css/capitulo2.css
@@ -1510,6 +1510,22 @@
   animation: portalSparksDrift 2.8s ease-in-out infinite;
 }
 
+.guardioes-final-portal.porta-concluida {
+  filter: grayscale(1) brightness(0.7);
+}
+
+.guardioes-final-portal.porta-concluida .portal-vortex,
+.guardioes-final-portal.porta-concluida .portal-fog,
+.guardioes-final-portal.porta-concluida .portal-sparks {
+  opacity: 0;
+  animation: none;
+}
+
+.guardioes-final-portal-button.porta-concluida {
+  cursor: default;
+  pointer-events: none;
+}
+
 @keyframes portalFogBackDrift {
   0%,
   100% {

--- a/public/assets/css/capitulo3.css
+++ b/public/assets/css/capitulo3.css
@@ -1010,6 +1010,17 @@ strong{
     brightness(0.72);
 }
 
+.portal.porta-concluida {
+  cursor: default;
+  filter: grayscale(1) brightness(0.7);
+}
+
+.portal.porta-concluida .portal-img,
+.portal.porta-concluida .ampulheta-img,
+.portal.porta-concluida .ampulheta2-img {
+  animation: none;
+}
+
 .ampulheta-link {
   position: absolute;
   left: 50%;

--- a/public/assets/css/capitulo4.css
+++ b/public/assets/css/capitulo4.css
@@ -3912,6 +3912,25 @@ transition: opacity 1.4s ease;
   border-radius: 12px;
 }
 
+.porta-boss-scene.porta-concluida {
+  cursor: default;
+  filter: grayscale(1) brightness(0.72);
+}
+
+.porta-boss-scene.porta-concluida::before {
+  opacity: 0.12;
+  animation: none;
+}
+
+.porta-boss-scene.porta-concluida .porta-boss-img {
+  animation: none;
+}
+
+.porta-boss-scene.porta-concluida .porta-boss-state {
+  opacity: 1;
+  color: #d6c7a0;
+}
+
 @keyframes porta-boss-shadow-flow {
   0%, 100% {
     filter:

--- a/public/assets/css/capitulo5.css
+++ b/public/assets/css/capitulo5.css
@@ -4336,6 +4336,22 @@
     drop-shadow(0 22px 36px rgba(0, 0, 0, 0.46));
 }
 
+.porta-final-stage.porta-concluida .porta-final-scene,
+.porta-final-stage.porta-concluida .porta-final-image {
+  cursor: default;
+}
+
+.porta-final-stage.porta-concluida .porta-final-image {
+  filter: grayscale(1) brightness(0.74)
+    drop-shadow(0 22px 36px rgba(0, 0, 0, 0.46));
+}
+
+.porta-final-stage.porta-concluida .porta-final-glow,
+.porta-final-stage.porta-concluida .porta-final-entrar-text {
+  opacity: 0;
+  animation: none;
+}
+
 @keyframes portaFinalGlowRoxo {
   0%,
   100% {

--- a/public/assets/js/capitulo1.js
+++ b/public/assets/js/capitulo1.js
@@ -221,6 +221,39 @@ function configurarProgressoVisual() {
   secoes.forEach((secao) => observer.observe(secao));
 }
 
+function configurarBarraProgressoResponsiva() {
+  const barra = document.querySelector(".chapter-progress-wrap");
+
+  if (!barra) return;
+
+  const espaco = document.createElement("div");
+  barra.before(espaco);
+
+  function atualizarBarra() {
+    const mobile = window.innerWidth <= 768;
+
+    if (!mobile) {
+      barra.classList.remove("is-fixed");
+      espaco.style.height = "";
+      return;
+    }
+
+    if (!barra.classList.contains("is-fixed")) {
+      espaco.style.height = "";
+    }
+
+    const limite = espaco.getBoundingClientRect().top + window.scrollY;
+    const fixa = window.scrollY >= limite;
+
+    espaco.style.height = fixa ? `${barra.offsetHeight}px` : "";
+    barra.classList.toggle("is-fixed", fixa);
+  }
+
+  window.addEventListener("scroll", atualizarBarra, { passive: true });
+  window.addEventListener("resize", atualizarBarra);
+  atualizarBarra();
+}
+
 function configurarPilares() {
   const card = document.getElementById("pilar-info");
 
@@ -765,6 +798,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   ajustarScrollPorHashInicial();
   configurarRevealNoScroll();
   configurarProgressoVisual();
+  configurarBarraProgressoResponsiva();
   configurarPilares();
   configurarRunas();
   configurarPrincipios();

--- a/public/assets/js/capitulo1.js
+++ b/public/assets/js/capitulo1.js
@@ -613,6 +613,7 @@ function configurarPortaDesafio() {
   if (!portaBoss) return;
 
   function entrarNoDesafio() {
+    if (portaBoss.classList.contains("porta-concluida")) return;
     if (!portaBoss.classList.contains("porta-liberada")) return;
 
     localStorage.setItem("moduloAtual", ID_MODULO);
@@ -723,6 +724,42 @@ function aoConcluirCapitulo1() {
   });
 }
 
+function moduloTemDesafioConcluido(modulo) {
+  return Boolean(
+    modulo?.desafio_concluido ||
+      (modulo?.historia_concluida && !modulo?.desafio_atual),
+  );
+}
+
+function aplicarPortaConcluida() {
+  const portaBoss = document.getElementById("portaBossScene");
+  const btnConcluir = document.getElementById("btnConcluirHistoria");
+  const status = document.getElementById("statusHistoria");
+  const tooltip = document.querySelector(".porta-boss-tooltip");
+
+  if (btnConcluir) {
+    btnConcluir.classList.add("hidden");
+  }
+
+  if (status) {
+    status.textContent =
+      "Desafio já vencido. Esta porta agora permanece como registro da sua jornada.";
+  }
+
+  if (tooltip) {
+    tooltip.textContent = "Porta já vencida. Continue pelo mapa.";
+  }
+
+  if (!portaBoss) return;
+
+  portaBoss.classList.remove("porta-liberada");
+  portaBoss.classList.add("porta-concluida");
+  portaBoss.removeAttribute("role");
+  portaBoss.removeAttribute("tabindex");
+  portaBoss.setAttribute("aria-disabled", "true");
+  portaBoss.setAttribute("aria-label", "Desafio do módulo 1 já vencido");
+}
+
 // isso resolve o problema de o progresso "sumir" quando o usuário atualiza a página.
 async function carregarEstadoHistoria() {
   // pega o token salvo no navegador. Esse token identifica qual usuário está logado.
@@ -749,6 +786,11 @@ async function carregarEstadoHistoria() {
 
     // Procura especificamente o módulo atual (capítulo 1).
     const modulo = data.modulos.find((m) => Number(m.id_modulo) === ID_MODULO);
+
+    if (moduloTemDesafioConcluido(modulo)) {
+      aplicarPortaConcluida();
+      return;
+    }
 
     if (!modulo) return;
 

--- a/public/assets/js/capitulo2.js
+++ b/public/assets/js/capitulo2.js
@@ -404,6 +404,104 @@ function entrarNoDesafioCapitulo2() {
   window.location.href = ROTA_DESAFIO_CAPITULO2;
 }
 
+function moduloTemDesafioConcluidoCapitulo2(modulo) {
+  return Boolean(
+    modulo?.desafio_concluido ||
+      (modulo?.historia_concluida && !modulo?.desafio_atual),
+  );
+}
+
+function aplicarPortaConcluidaCapitulo2() {
+  const btnConcluir = document.getElementById("btnConcluirHistoriaCapitulo2");
+  const btnDesafio = document.getElementById("btnIrDesafioCapitulo2");
+  const porta = document.getElementById("porta2Scene");
+  const portal = document.querySelector(".guardioes-final-portal");
+  const kicker = document.querySelector(".guardioes-final-dialogo-portal .porta2-kicker");
+
+  if (btnConcluir) {
+    btnConcluir.classList.add("hidden");
+  }
+
+  if (btnDesafio) {
+    btnDesafio.classList.add("hidden");
+  }
+
+  if (kicker) {
+    kicker.textContent = "Portal já vencido";
+  }
+
+  if (portal) {
+    portal.classList.remove("is-portal-active");
+    portal.classList.add("porta-concluida");
+  }
+
+  if (!porta) return;
+
+  porta.classList.remove("porta-liberada");
+  porta.classList.add("porta-concluida");
+  porta.disabled = true;
+  porta.setAttribute("aria-disabled", "true");
+  porta.setAttribute("aria-label", "Desafio do módulo 2 já vencido");
+}
+
+function aplicarPortaLiberadaCapitulo2() {
+  const btnConcluir = document.getElementById("btnConcluirHistoriaCapitulo2");
+  const btnDesafio = document.getElementById("btnIrDesafioCapitulo2");
+  const porta = document.getElementById("porta2Scene");
+  const portal = document.querySelector(".guardioes-final-portal");
+
+  if (btnConcluir) {
+    btnConcluir.classList.add("hidden");
+  }
+
+  if (btnDesafio) {
+    btnDesafio.classList.remove("hidden");
+  }
+
+  if (porta) {
+    porta.disabled = false;
+    porta.classList.add("porta-liberada");
+    porta.classList.remove("porta-concluida");
+    porta.removeAttribute("aria-disabled");
+  }
+
+  if (portal) {
+    portal.classList.add("is-portal-active");
+    portal.classList.remove("porta-concluida");
+  }
+}
+
+async function carregarEstadoHistoriaCapitulo2() {
+  const token = obterTokenCapitulo2();
+
+  if (!token) return;
+
+  try {
+    const response = await fetch("/api/progresso/mapa", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    const data = await response.json();
+
+    if (!response.ok || !Array.isArray(data.modulos)) return;
+
+    const modulo = data.modulos.find((item) => Number(item.id_modulo) === ID_MODULO);
+
+    if (moduloTemDesafioConcluidoCapitulo2(modulo)) {
+      aplicarPortaConcluidaCapitulo2();
+      return;
+    }
+
+    if (modulo?.historia_concluida) {
+      aplicarPortaLiberadaCapitulo2();
+    }
+  } catch (error) {
+    console.error(error);
+  }
+}
+
 function configurarConclusaoCapitulo2() {
   const btnConcluir = document.getElementById("btnConcluirHistoriaCapitulo2");
   const btnDesafio = document.getElementById("btnIrDesafioCapitulo2");
@@ -419,6 +517,7 @@ function configurarConclusaoCapitulo2() {
 
   if (porta) {
     porta.addEventListener("click", () => {
+      if (porta.classList.contains("porta-concluida")) return;
       if (!porta.classList.contains("porta-liberada")) return;
       entrarNoDesafioCapitulo2();
     });
@@ -468,7 +567,7 @@ function configurarDesbloqueioNavbarCapitulo2() {
   observer.observe(secaoFinal);
 }
 
-document.addEventListener("DOMContentLoaded", () => {
+document.addEventListener("DOMContentLoaded", async () => {
   configurarMangaIntroCapitulo2();
   configurarMangaFinalCapitulo2();
   configurarScrollCapitulo2();
@@ -479,5 +578,6 @@ document.addEventListener("DOMContentLoaded", () => {
   configurarConclusaoCapitulo2();
   configurarParallaxPortalCapitulo2();
   configurarDesbloqueioNavbarCapitulo2();
+  await carregarEstadoHistoriaCapitulo2();
   ajustarHashInicialCapitulo2();
 });

--- a/public/assets/js/capitulo3.js
+++ b/public/assets/js/capitulo3.js
@@ -186,6 +186,43 @@ function definirPortalLiberado(liberado) {
   }
 }
 
+function moduloTemDesafioConcluido(modulo) {
+  return Boolean(
+    modulo?.desafio_concluido ||
+      (modulo?.historia_concluida && !modulo?.desafio_atual),
+  );
+}
+
+function aplicarPortalConcluido() {
+  historiaConcluida = false;
+
+  const portal = document.getElementById("portalScene");
+  const linkPortal = document.querySelector(".ampulheta-link");
+  const btnConcluir = document.getElementById("btnConcluirHistoria");
+  const status = document.getElementById("statusHistoria");
+
+  if (btnConcluir) {
+    btnConcluir.classList.add("hidden");
+  }
+
+  if (status) {
+    status.textContent =
+      "Desafio já vencido. Este portal agora permanece fechado para revisão.";
+  }
+
+  if (portal) {
+    portal.classList.remove("is-locked");
+    portal.classList.add("porta-concluida");
+  }
+
+  if (!linkPortal) return;
+
+  linkPortal.removeAttribute("href");
+  linkPortal.setAttribute("aria-disabled", "true");
+  linkPortal.setAttribute("tabindex", "-1");
+  linkPortal.setAttribute("aria-label", "Desafio do módulo 3 já vencido");
+}
+
 function configurarPortalDoDesafio() {
   definirPortalLiberado(false);
 
@@ -286,6 +323,11 @@ async function carregarEstadoHistoria() {
     if (!response.ok) return;
 
     const modulo = data.modulos.find((m) => Number(m.id_modulo) === ID_MODULO);
+
+    if (moduloTemDesafioConcluido(modulo)) {
+      aplicarPortalConcluido();
+      return;
+    }
 
     if (!modulo?.historia_concluida) return;
 

--- a/public/assets/js/capitulo4.js
+++ b/public/assets/js/capitulo4.js
@@ -1579,12 +1579,51 @@ function liberarPortaDesafio() {
   if (!gate) return;
 
   gate.classList.add("porta-liberada");
+  gate.classList.remove("porta-concluida");
+  gate.removeAttribute("aria-disabled");
   gate.setAttribute("role", "button");
   gate.setAttribute("tabindex", "0");
   gate.setAttribute("aria-label", "Entrar no desafio do modulo 4");
 
   if (state) {
     state.textContent = "Entrar no desafio";
+  }
+}
+
+function moduloTemDesafioConcluido(modulo) {
+  return Boolean(
+    modulo?.desafio_concluido ||
+      (modulo?.historia_concluida && !modulo?.desafio_atual),
+  );
+}
+
+function aplicarPortaConcluida() {
+  const gate = document.getElementById("portaBossScene");
+  const state = gate?.querySelector(".porta-boss-state");
+  const button = document.getElementById("btnConcluirHistoria");
+  const status = document.getElementById("statusHistoria");
+
+  if (button) {
+    button.classList.add("hidden");
+  }
+
+  if (status) {
+    status.dataset.completed = "true";
+    status.textContent =
+      "Desafio já vencido. Esta porta agora permanece como registro da sua jornada.";
+  }
+
+  if (!gate) return;
+
+  gate.classList.remove("porta-liberada");
+  gate.classList.add("porta-concluida");
+  gate.removeAttribute("role");
+  gate.removeAttribute("tabindex");
+  gate.setAttribute("aria-disabled", "true");
+  gate.setAttribute("aria-label", "Desafio do módulo 4 já vencido");
+
+  if (state) {
+    state.textContent = "Desafio já vencido";
   }
 }
 
@@ -1602,6 +1641,7 @@ function configurarPortaDesafio() {
   if (!gate) return;
 
   function entrarNoDesafio() {
+    if (gate.classList.contains("porta-concluida")) return;
     if (!gate.classList.contains("porta-liberada")) return;
 
     localStorage.setItem("moduloAtual", ID_MODULO);
@@ -1634,6 +1674,11 @@ async function carregarEstadoHistoria() {
     if (!response.ok || !Array.isArray(data.modulos)) return;
 
     const moduleState = data.modulos.find((module) => Number(module.id_modulo) === ID_MODULO);
+
+    if (moduloTemDesafioConcluido(moduleState)) {
+      aplicarPortaConcluida();
+      return;
+    }
 
     if (!moduleState?.historia_concluida) return;
 

--- a/public/assets/js/capitulo5.js
+++ b/public/assets/js/capitulo5.js
@@ -297,6 +297,69 @@ async function concluirHistoria() {
   }
 }
 
+function moduloTemDesafioConcluido(modulo) {
+  return Boolean(
+    modulo?.desafio_concluido ||
+      (modulo?.historia_concluida && !modulo?.desafio_atual),
+  );
+}
+
+function aplicarPortaFinalConcluida() {
+  const portaFinalStage = document.getElementById("encounter-porta");
+  const portaFinalLockZone = document.getElementById("portaFinalLockZone");
+  const portaFinalImgFechada = document.getElementById("portaFinalImgFechada");
+  const portaFinalImgAberta = document.getElementById("portaFinalImgAberta");
+  const portaFinalFeedback = document.getElementById("portaFinalFeedback");
+  const portaBloqueada = document.getElementById("portaBloqueada");
+  const btnConcluir = document.getElementById("btnConcluirHistoria");
+  const btnEntrarDesafio = document.getElementById("btnEntrarDesafio");
+  const status = document.getElementById("statusHistoria");
+
+  if (btnConcluir) {
+    btnConcluir.classList.add("hidden");
+  }
+
+  if (btnEntrarDesafio) {
+    btnEntrarDesafio.classList.add("hidden");
+  }
+
+  if (status) {
+    status.textContent =
+      "Desafio final já vencido. Esta porta agora permanece como registro da sua jornada.";
+  }
+
+  if (portaBloqueada) {
+    portaBloqueada.textContent =
+      "Esta porta final já foi vencida. Continue sua jornada pelo mapa ou consulte seu certificado.";
+    portaBloqueada.classList.remove("liberada");
+  }
+
+  if (portaFinalFeedback) {
+    portaFinalFeedback.textContent =
+      "Porta já vencida. O desafio final não pode ser acessado por aqui novamente.";
+    portaFinalFeedback.classList.remove("hidden");
+  }
+
+  if (portaFinalImgFechada) {
+    portaFinalImgFechada.classList.add("hidden");
+  }
+
+  if (portaFinalImgAberta) {
+    portaFinalImgAberta.classList.remove("hidden");
+  }
+
+  if (portaFinalLockZone) {
+    portaFinalLockZone.classList.add("hidden");
+  }
+
+  if (!portaFinalStage) return;
+
+  portaFinalStage.classList.add("porta-final-aberta");
+  portaFinalStage.classList.add("porta-concluida");
+  portaFinalStage.classList.remove("is-unlocked");
+  portaFinalStage.setAttribute("aria-label", "Desafio final já vencido");
+}
+
 async function carregarEstadoHistoria() {
   const token = obterToken();
 
@@ -322,6 +385,11 @@ async function carregarEstadoHistoria() {
     if (!modulo || !modulo.historia_concluida) return;
 
     historia5ConcluidaNoBackend = true;
+
+    if (moduloTemDesafioConcluido(modulo)) {
+      aplicarPortaFinalConcluida();
+      return;
+    }
 
     if (estaEmReplayTemporalCapitulo5()) {
       if (btnConcluir) {
@@ -2704,6 +2772,13 @@ function configurarPortaFinal() {
   }
 
   function entrarNoDesafioFinalPelaPorta() {
+    if (portaFinalStage.classList.contains("porta-concluida")) {
+      mostrarFeedbackPorta(
+        "Esta porta já foi vencida. Continue sua jornada pelo mapa ou consulte seu certificado.",
+      );
+      return;
+    }
+
     if (!portaFoiAberta) {
       mostrarFeedbackPorta(
         "A porta ainda está fechada. Use a Chave MVP na fechadura para liberar o desafio final.",
@@ -2827,6 +2902,10 @@ function configurarEntradaDesafio() {
   if (!btnEntrarDesafio) return;
 
   btnEntrarDesafio.addEventListener("click", () => {
+    const portaFinalStage = document.getElementById("encounter-porta");
+
+    if (portaFinalStage?.classList.contains("porta-concluida")) return;
+
     localStorage.setItem("moduloAtual", ID_MODULO);
     window.location.href = "/desafio1";
   });
@@ -2876,6 +2955,7 @@ function sincronizarVisualInicialPortaFinal() {
   const btnEntrarDesafio = document.getElementById("btnEntrarDesafio");
 
   if (!portaFinalStage) return;
+  if (portaFinalStage.classList.contains("porta-concluida")) return;
   if (etapaAtualCapitulo5 !== "porta-final") return;
   if (!chaveMvpUsadaNaPorta) return;
 


### PR DESCRIPTION
Implementa o bloqueio de portais/portas de capítulos cujo desafio já foi concluído, evitando que o jogador revisite uma porta antiga e seja redirecionado para o desafio atual da conta.

**Principais mudanças**

- Adiciona o estado `porta-concluida` nos capítulos 1 a 5.
- Bloqueia clique/entrada em portas de módulos já vencidos.
- Mantém a revisão do conteúdo dos capítulos disponível.
- Exibe mensagens indicando que o desafio daquela porta já foi superado.
- Aplica visual inativo/dessaturado para portas e portais concluídos.
- Reaproveita a regra já usada no projeto: `historia_concluida && !desafio_atual`.

**Arquivos alterados**

- `public/assets/js/capitulo1.js` até `capitulo5.js`
- `public/assets/css/capitulo1.css` até `capitulo5.css`

**Validação**

- `node --check` passou nos JS dos capítulos 1 a 5.
- `npm test` ainda apresenta falhas estruturais já existentes no projeto, mas JS/CSS/EJS passaram.